### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/msshashank1997/293774a2-8be6-4516-9187-2c4e19a2772e/4725d501-fef0-4a44-b009-fcfa1822319b/_apis/work/boardbadge/4ed58772-45b3-44f3-a86e-06b4fab8d6de)](https://dev.azure.com/msshashank1997/293774a2-8be6-4516-9187-2c4e19a2772e/_boards/board/t/4725d501-fef0-4a44-b009-fcfa1822319b/Microsoft.RequirementCategory)
 # workflow


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#25](https://dev.azure.com/msshashank1997/293774a2-8be6-4516-9187-2c4e19a2772e/_workitems/edit/25). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.